### PR TITLE
ensure migrations run in order

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -19,7 +19,7 @@ def migrate_db
     DB.execute("DROP TABLE #{table}")
   end
 
-  Dir[File.join(File.dirname(__FILE__), "../db/migrate", "*.rb")].sort.each do |f| 
+  Dir[File.join(File.dirname(__FILE__), "../db/migrate", "*.rb")].sort!.each do |f| 
     require f
     migration = Kernel.const_get(f.split("/").last.split(".rb").first.gsub(/\d+/, "").split("_").collect{|w| w.strip.capitalize}.join())
     migration.migrate(:up)


### PR DESCRIPTION
I was having [the same issue](https://github.com/learn-co-students/Active-Record-Association-Methods-v-000/issues/40) as @thegands.  Migrations not executing in the proper order.  He said using `reverse.each` worked for him, but that didn't work for me so I tried `sort!.each` and it worked.

Mad props to @thegands for all his research when he went through this same issue!
